### PR TITLE
Make test timeout configurable.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ var fs = require("fs"),
 
 var skeldir = path.join(__dirname, "skel"),
     srcdir = path.join(process.env.GAUGE_PROJECT_ROOT, "tests"),
-    testCode = "step_implementation.js";
+    envdir = path.join(process.env.GAUGE_PROJECT_ROOT, "env", "default"),
+    testCode = "step_implementation.js",
+    jsPropertyFile = "js.properties";
 
 if(process.argv[2] === "--init") {
 
@@ -16,6 +18,15 @@ if(process.argv[2] === "--init") {
     } else {
       fs.createReadStream(path.join(skeldir, testCode))
         .pipe(fs.createWriteStream(path.join(srcdir, testCode)));
+    }
+  });
+
+  fs.mkdir(envdir, 484, function(err) {
+    if (err && err.code !== "EEXIST") {
+      console.error(err);
+    } else {
+      fs.createReadStream(path.join(skeldir, jsPropertyFile))
+        .pipe(fs.createWriteStream(path.join(envdir, jsPropertyFile)));
     }
   });
 }

--- a/skel/js.properties
+++ b/skel/js.properties
@@ -1,0 +1,4 @@
+#js.properties
+#settings related to gauge-js.
+
+test_timeout = 1000

--- a/src/executor.js
+++ b/src/executor.js
@@ -2,7 +2,8 @@
 var factory = require("./response-factory");
 var Q = require("q");
 var Test = require("./test");
-
+/* If test_timeout env variable is not available set the default to 1000ms */
+var timeout = process.env.test_timeout || 1000;
 
 // Source: http://stackoverflow.com/a/26034767/575242
 var hasIntersection = function (arr1, arr2) {
@@ -37,7 +38,7 @@ var executeStep = function(request) {
   var parameters = request.executeStepRequest.parameters.map(function(item) {
     return item.value ? item.value : item.table;
   });
-  new Test(stepRegistry.get(parsedStepText).fn, parameters).run().then(
+  new Test(stepRegistry.get(parsedStepText).fn, parameters, timeout).run().then(
     function(result) {
       var response = factory.createExecutionStatusResponse(request.messageId, false, result.duration);
       deferred.resolve(response);
@@ -86,7 +87,7 @@ var executeHook = function(request, hookLevel, currentExecutionInfo) {
   };
 
   for (var i = 0; i < filteredHooks.length; i++) {
-    new Test(filteredHooks[i].fn, [currentExecutionInfo], 10000).run().then(onPass, onError);
+    new Test(filteredHooks[i].fn, [currentExecutionInfo], timeout).run().then(onPass, onError);
   }
 
   return deferred.promise;


### PR DESCRIPTION
Fixes #7 .
- Reading ```test_timeout``` env variable in executor.js and passes it down to each instance of test run.
- If ```test_timeout``` is not found default value is ```1000ms```
- While initialising project copy ```js.properties``` into ```env/default``` directory.