### PR TITLE
Done method supports error parameter to fail steps

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -58,7 +58,7 @@ var runFn = function() {
 
 var runFnAsync = function() {
   var self = this;
-  self.params.push( function() { done.call(self); } );
+  self.params.push( function(err) { done.call(self, err); } );
   resetTimeout.call(self);
   
   try {


### PR DESCRIPTION
when calling done(err) from a gauge step, an error is assumed at the step level, failing it. This shows up both on the console and on the report (assuming html-report plugin is being used)