### PR TITLE
Proto3 support for Gauge-js

### DIFF
--- a/js.json
+++ b/js.json
@@ -1,6 +1,6 @@
 {
   "id" : "js",
-  "version" : "1.3.1",
+  "version" : "2.0.0",
   "description": "Javascript support for gauge",
   "install": {
     "windows": [],
@@ -19,7 +19,7 @@
   },
   "lib": "libs",
   "gaugeVersionSupport": {
-    "minimum": "0.5.1",
+    "minimum": "0.8.0",
     "maximum": ""
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "escodegen": "^1.8.0",
     "esprima": "^2.7.2",
     "estraverse": "^4.1.1",
-    "protobufjs": "^4.1.2",
-    "protocol-buffers": "^3.1.3",
+    "protobufjs": "^5.0.2",
     "q": "^1.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-js",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "JavaScript runner for Gauge",
   "main": "index.js",
   "scripts": {

--- a/src/response-factory.js
+++ b/src/response-factory.js
@@ -92,10 +92,9 @@ exports.createExecutionStatusResponse = function (messageId, isFailed, execution
         failed: isFailed,
         recoverableError: recoverable,
         executionTime: executionTime || 0,
-        stackTrace: err && err.stack ? err.stack : null,
-        errorMessage: err ? err.toString() : null,
-        message: msg || [],
-        screenShot: null
+        stackTrace: err && err.stack ? err.stack : "",
+        errorMessage: err ? err.toString() : "",
+        message: msg || []
       }
     }
   });

--- a/test/executor-test.js
+++ b/test/executor-test.js
@@ -16,7 +16,6 @@ describe("Executing steps", function() {
     executeStepRequest: {
       actualStepText: "Say \"hello\" to \"gauge\"",
       parsedStepText: "Say {} to {}",
-      scenarioFailing: null,
       parameters: [
         { parameterType: 1, value: "hello", name: "", table: null },
         { parameterType: 1, value: "gauge", name: "", table: null }
@@ -30,8 +29,6 @@ describe("Executing steps", function() {
     executeStepRequest: {
       actualStepText: "failing test",
       parsedStepText: "failing test",
-      scenarioFailing: null,
-      parameters: []
     }
   });
 


### PR DESCRIPTION
gauge-js now uses gauge-proto with proto3

This should make gauge-js compatible with Gauge 0.8.0 and above.

/cc @kaustavdm @renjithgr 